### PR TITLE
Add warnings in both readme and in the build script about why your stuff...

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,7 @@ elm-kernel-debug
 ====
 
 Compile kernel code and test it.
+
+## Note
+
+After running `build.sh`, check the `0.19.0/package` folder for your module. If you see multiple versions of it in there, your changes may not be built into `index.html`! In that case, adjust the version of your module in its `elm.json` to match the one the Elm compiler brings in.

--- a/build.sh
+++ b/build.sh
@@ -20,7 +20,8 @@ rm -rf ./elm-stuff
 elm make --docs=documentation.json
 cd $here
 
-target_dir=0.19.0/package/$author/$package/$version
+target_module=0.19.0/package/$author/$package
+target_dir=$target_module/$version
 rm -rf $target_dir
 mkdir -p $target_dir
 cp -r $package/* $target_dir
@@ -29,3 +30,14 @@ cd app
 rm -rf ./elm-stuff
 elm make src/Main.elm --output=../index.html
 cd $here
+
+number_of_versions=`ls $target_module | wc -w | tr -d '[:space:]'`
+
+if [ $number_of_versions -gt 1 ]
+  then
+  echo ""
+  echo "[WARNING] $number_of_versions versions of $package were found at $target_module:"
+  ls $target_module
+  echo "Your modified code may not be compiled in."
+  echo "Consider modifying the version in $package/elm.json"
+fi


### PR DESCRIPTION
...isn't getting built when one version of a module wins over another.